### PR TITLE
Fixed typo for deviceId function name

### DIFF
--- a/src/AppHost.ts
+++ b/src/AppHost.ts
@@ -46,7 +46,7 @@ export interface IAppHost {
     /**
      * A unique and persistent device identifier
      */
-    deviceID(): string;
+    deviceId(): string;
 
     /**
      * A display name from the device


### PR DESCRIPTION
The function was specified as `deviceID`, where in fact the function has to be called `deviceId`